### PR TITLE
Fixes #30: Better testing around NodeHeaderChange and fixes a few bugs that were found

### DIFF
--- a/src/main/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChange.java
+++ b/src/main/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChange.java
@@ -17,6 +17,10 @@ public class NodeHeaderChange extends AbstractSvnDumpMutator {
     private boolean updatedNode;
 
     public NodeHeaderChange(int targetRevision, String nodeAction, String path, SvnNodeHeader headerToChange, String oldValue, String newValue) {
+        if(oldValue == null) {
+            throw new IllegalArgumentException("Cannot accept null paramter: oldValue");
+        }
+
         this.targetRevision = targetRevision;
         this.nodeAction = nodeAction;
         this.nodePath = path;
@@ -27,12 +31,8 @@ public class NodeHeaderChange extends AbstractSvnDumpMutator {
 
     @Override
     public void consume(SvnRevision revision) {
-        if(foundTargetRevision) {
-            if(!updatedNode) {
-                throw new IllegalArgumentException("The node \"" + nodeAction + " " + nodePath + "\" was not found at revision " + targetRevision);
-            }
-            super.consume(revision);
-            return;
+        if(foundTargetRevision && !updatedNode) {
+            throw new IllegalArgumentException("The node \"" + nodeAction + " " + nodePath + "\" was not found at revision " + targetRevision);
         }
 
         if(revision.getNumber() == targetRevision) {
@@ -50,7 +50,7 @@ public class NodeHeaderChange extends AbstractSvnDumpMutator {
 
         if (nodeAction.equals(node.get(SvnNodeHeader.ACTION)) &&
                 nodePath.equals(node.get(SvnNodeHeader.PATH))) {
-            if(oldValue != null && !oldValue.equals(node.get(headerToChange))) {
+            if(!oldValue.equals(node.get(headerToChange))) {
                 throw new IllegalArgumentException("The old value for the " + headerToChange.name() + " property is not \"" + oldValue + "\"");
             }
             node.getHeaders().put(headerToChange, newValue);

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
@@ -176,4 +176,91 @@ public class NodeHeaderChangeTest {
             }
         }
     }
+
+    @Test
+    public void should_respect_revision_number_earlier() throws ParseException {
+        String dumpFilePath = "dumps/add_and_multiple_change.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(5));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(3).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(4).getNodes().size(), is(1));
+            {
+                SvnNode node = dump.getRevisions().get(1).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("add")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+            SvnNode node = dump.getRevisions().get(2).getNodes().get(0);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+            assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+        }{
+            SvnNode node = dump.getRevisions().get(3).getNodes().get(0);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+            assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+        }{
+            SvnNode node = dump.getRevisions().get(4).getNodes().get(0);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+            assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+        }
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(2, "change", "file1.txt", SvnNodeHeader.ACTION, "change", "delete");
+            SvnDump updatedDump = SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+
+            assertThat(updatedDump.getRevisions().size(), is(5));
+            assertThat(updatedDump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(updatedDump.getRevisions().get(1).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(2).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(3).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(4).getNodes().size(), is(1));
+            {
+                SvnNode node = updatedDump.getRevisions().get(1).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("add")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(2).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(3).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(4).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void old_value_does_not_match() throws ParseException {
+        String dumpFilePath = "dumps/svn_multi_file_delete.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(3));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(3));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(3));
+            SvnNode node = dump.getRevisions().get(2).getNodes().get(1);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+            assertNull(node.get(SvnNodeHeader.KIND));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("README2.txt")));
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(2, "delete", "README2.txt", SvnNodeHeader.PATH, "README1.txt", "README3.txt");
+            SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+        }
+    }
 }

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
@@ -44,4 +44,69 @@ public class NodeHeaderChangeTest {
             assertThat(changedNode.get(SvnNodeHeader.PATH), is(equalTo("README2.txt")));
         }
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_exception_when_not_found() throws ParseException {
+        String dumpFilePath = "dumps/svn_multi_file_delete.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(3));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(3));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(3));
+            SvnNode node = dump.getRevisions().get(2).getNodes().get(1);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+            assertNull(node.get(SvnNodeHeader.KIND));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("README2.txt")));
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(2, "add", "README2.txt", SvnNodeHeader.ACTION, "delete", "add");
+            SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_exception_when_no_node_matched() throws ParseException {
+        String dumpFilePath = "dumps/svn_multi_file_delete.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(3));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(3));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(3));
+            SvnNode node = dump.getRevisions().get(2).getNodes().get(1);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+            assertNull(node.get(SvnNodeHeader.KIND));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("README2.txt")));
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(1, "delete", "README2.txt", SvnNodeHeader.ACTION, "delete", "add");
+            SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throws_exception_on_missing_revision() throws ParseException {
+        String dumpFilePath = "dumps/svn_multi_file_delete.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(3));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(3));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(3));
+            SvnNode node = dump.getRevisions().get(2).getNodes().get(1);
+            assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+            assertNull(node.get(SvnNodeHeader.KIND));
+            assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("README2.txt")));
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(4, "add", "README2.txt", SvnNodeHeader.ACTION, "delete", "add");
+            SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void does_not_allow_null_old_value() throws ParseException {
+        new NodeHeaderChange(4, "add", "README2.txt", SvnNodeHeader.ACTION, null, "add");
+    }
 }

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/NodeHeaderChangeTest.java
@@ -109,4 +109,71 @@ public class NodeHeaderChangeTest {
     public void does_not_allow_null_old_value() throws ParseException {
         new NodeHeaderChange(4, "add", "README2.txt", SvnNodeHeader.ACTION, null, "add");
     }
+
+    @Test
+    public void should_respect_revision_number() throws ParseException {
+        String dumpFilePath = "dumps/add_and_multiple_change.dump";
+        {
+            SvnDump dump = SvnDumpFileParserTest.parse(dumpFilePath);
+
+            assertThat(dump.getRevisions().size(), is(5));
+            assertThat(dump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(dump.getRevisions().get(1).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(2).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(3).getNodes().size(), is(1));
+            assertThat(dump.getRevisions().get(4).getNodes().size(), is(1));
+            {
+                SvnNode node = dump.getRevisions().get(1).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("add")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = dump.getRevisions().get(2).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = dump.getRevisions().get(3).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = dump.getRevisions().get(4).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }
+        }{
+            SvnDumpMutator actionChange = new NodeHeaderChange(4, "change", "file1.txt", SvnNodeHeader.ACTION, "change", "delete");
+            SvnDump updatedDump = SvnDumpFileParserTest.consume(dumpFilePath, actionChange);
+
+            assertThat(updatedDump.getRevisions().size(), is(5));
+            assertThat(updatedDump.getRevisions().get(0).getNodes().size(), is(0));
+            assertThat(updatedDump.getRevisions().get(1).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(2).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(3).getNodes().size(), is(1));
+            assertThat(updatedDump.getRevisions().get(4).getNodes().size(), is(1));
+            {
+                SvnNode node = updatedDump.getRevisions().get(1).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("add")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(2).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(3).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("change")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }{
+                SvnNode node = updatedDump.getRevisions().get(4).getNodes().get(0);
+                assertThat(node.get(SvnNodeHeader.ACTION), is(equalTo("delete")));
+                assertThat(node.get(SvnNodeHeader.KIND), is(equalTo("file")));
+                assertThat(node.get(SvnNodeHeader.PATH), is(equalTo("file1.txt")));
+            }
+        }
+    }
 }

--- a/src/test/resources/dumps/Makefile
+++ b/src/test/resources/dumps/Makefile
@@ -18,3 +18,6 @@ simple_branch_and_merge:
 
 utf8_log_message:
 	./scripts/utf8_log_message.sh > utf8_log_message.dump
+
+add_and_multiple_change:
+	./scripts/add_and_multiple_change.sh > add_and_multiple_change.dump

--- a/src/test/resources/dumps/add_and_multiple_change.dump
+++ b/src/test/resources/dumps/add_and_multiple_change.dump
@@ -1,0 +1,132 @@
+SVN-fs-dump-format-version: 2
+
+UUID: 26343198-1d6a-4304-a4fe-b7d6fccd44a5
+
+Revision-number: 0
+Prop-content-length: 56
+Content-length: 56
+
+K 8
+svn:date
+V 27
+2015-10-27T13:32:30.614008Z
+PROPS-END
+
+Revision-number: 1
+Prop-content-length: 116
+Content-length: 116
+
+K 10
+svn:author
+V 6
+cosmin
+K 8
+svn:date
+V 27
+2015-10-27T13:32:30.764656Z
+K 7
+svn:log
+V 15
+Initial commit.
+PROPS-END
+
+Node-path: file1.txt
+Node-kind: file
+Node-action: add
+Prop-content-length: 10
+Text-content-length: 20
+Text-content-md5: 4221d002ceb5d3c9e9137e495ceaa647
+Text-content-sha1: 804d716fc5844f1cc5516c8f0be7a480517fdea2
+Content-length: 30
+
+PROPS-END
+this is a test file
+
+
+Revision-number: 2
+Prop-content-length: 114
+Content-length: 114
+
+K 10
+svn:author
+V 6
+cosmin
+K 8
+svn:date
+V 27
+2015-10-27T13:32:30.853986Z
+K 7
+svn:log
+V 13
+Changed file.
+PROPS-END
+
+Node-path: file1.txt
+Node-kind: file
+Node-action: change
+Text-content-length: 13
+Text-content-md5: 5af7ab1f6a22ddd4f590664a39ce1004
+Text-content-sha1: 56cc699ada54eca15d2cd5592b6d7d9f970b2554
+Content-length: 13
+
+changed file
+
+
+Revision-number: 3
+Prop-content-length: 120
+Content-length: 120
+
+K 10
+svn:author
+V 6
+cosmin
+K 8
+svn:date
+V 27
+2015-10-27T13:32:30.966784Z
+K 7
+svn:log
+V 19
+Changed file again.
+PROPS-END
+
+Node-path: file1.txt
+Node-kind: file
+Node-action: change
+Text-content-length: 19
+Text-content-md5: 663c78de3de3fd763a60013140d9596f
+Text-content-sha1: 509d16a72d71207f9312dbab64000c6cd1be2800
+Content-length: 19
+
+changed file again
+
+
+Revision-number: 4
+Prop-content-length: 127
+Content-length: 127
+
+K 10
+svn:author
+V 6
+cosmin
+K 8
+svn:date
+V 27
+2015-10-27T13:32:31.073005Z
+K 7
+svn:log
+V 26
+Changed file a third time.
+PROPS-END
+
+Node-path: file1.txt
+Node-kind: file
+Node-action: change
+Text-content-length: 26
+Text-content-md5: 4b444b45901292ab301d693e525cb996
+Text-content-sha1: 7a685989aec9c1296c42fa05127dff7eee55ebb2
+Content-length: 26
+
+changed file a third time
+
+

--- a/src/test/resources/dumps/scripts/add_and_multiple_change.sh
+++ b/src/test/resources/dumps/scripts/add_and_multiple_change.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+SVNFLAGS="-q"
+
+CURDIR=$(pwd)
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+cd $SCRIPT_DIR
+
+./setup.sh
+
+cd svn-test/checkout/testrepo
+echo "this is a test file" > file1.txt
+svn add $SVNFLAGS file1.txt
+svn commit -m "Initial commit." $SVNFLAGS
+
+echo "changed file" > file1.txt
+svn commit -m "Changed file." $SVNFLAGS
+
+echo "changed file again" > file1.txt
+svn commit -m "Changed file again." $SVNFLAGS
+
+echo "changed file a third time" > file1.txt
+svn commit -m "Changed file a third time." $SVNFLAGS
+
+cd $SCRIPT_DIR
+./export.sh
+cd $CURDIR


### PR DESCRIPTION
It turns out that NodeHeaderChange didn't properly respect the revision number when modifying a node, so if the same node matched across revisions, all were changed.   Fix that, and get better coverage. 