### PR TITLE
Remove the dependency on TreeOfKnowledge from FileContentReplace.  

### DIFF
--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
@@ -3,25 +3,18 @@ package com.github.cstroe.svndumpgui.internal.transform.replace;
 import com.github.cstroe.svndumpgui.api.ContentChunk;
 import com.github.cstroe.svndumpgui.api.Node;
 import com.github.cstroe.svndumpgui.api.NodeHeader;
-import com.github.cstroe.svndumpgui.api.RepositoryConsumer;
 import com.github.cstroe.svndumpgui.api.RepositoryWriter;
 import com.github.cstroe.svndumpgui.api.Revision;
-import com.github.cstroe.svndumpgui.api.TreeOfKnowledge;
 import com.github.cstroe.svndumpgui.generated.ParseException;
 import com.github.cstroe.svndumpgui.generated.SvnDumpParser;
-import com.github.cstroe.svndumpgui.internal.AbstractRepositoryConsumerTest;
 import com.github.cstroe.svndumpgui.internal.ContentChunkImpl;
 import com.github.cstroe.svndumpgui.internal.NodeImpl;
 import com.github.cstroe.svndumpgui.internal.RevisionImpl;
-import com.github.cstroe.svndumpgui.internal.consumer.ImmutableTreeOfKnowledge;
-import com.github.cstroe.svndumpgui.internal.consumer.TreeOfKnowledgeImpl;
 import com.github.cstroe.svndumpgui.internal.utility.Md5;
 import com.github.cstroe.svndumpgui.internal.utility.Sha1;
 import com.github.cstroe.svndumpgui.internal.utility.TestUtil;
 import com.github.cstroe.svndumpgui.internal.writer.RepositoryInMemory;
 import com.github.cstroe.svndumpgui.internal.writer.SvnDumpWriter;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -35,14 +28,10 @@ import java.util.function.Predicate;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FileContentReplaceTest {
-    private Predicate<Node> MATCH_ANY = t -> true;
-    private Function<Node, ContentChunk> EMPTY_CHUNK = t -> new ContentChunkImpl(new byte[0]);
-
     @Test
     public void simple_replace() throws ParseException, NoSuchAlgorithmException {
         final String newFileContent = "No content.\n";
@@ -275,72 +264,5 @@ public class FileContentReplaceTest {
         TestUtil.assertEqualStreams(
                 TestUtil.openResource("dumps/add_and_change_copy_delete.dump"),
                 new ByteArrayInputStream(newDumpStream.toByteArray()));
-    }
-
-    @Test
-    public void getTreeOfKnowledge_should_be_idempotent() {
-        FileContentReplace fcr = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        assertTrue(fcr.getTreeOfKnowledge() == fcr.getTreeOfKnowledge());
-    }
-
-    @Test
-    public void setTreeOfKnowledge_with_immutable_tree() {
-        ImmutableTreeOfKnowledge tok = new ImmutableTreeOfKnowledge(new TreeOfKnowledgeImpl());
-
-        FileContentReplace fcr = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        fcr.setTreeOfKnowledge(tok);
-        assertTrue(tok == fcr.getTreeOfKnowledge());
-    }
-
-    @Test
-    public void treeofknowledge_is_shared() {
-        FileContentReplace fcr1 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        assertNotNull(fcr1.getTreeOfKnowledge());
-
-        FileContentReplace fcr2 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        assertFalse(fcr1.getTreeOfKnowledge() == fcr2.getTreeOfKnowledge());
-
-        fcr1.continueTo(fcr2);
-        assertTrue(fcr1.getTreeOfKnowledge() == fcr2.getTreeOfKnowledge());
-    }
-
-    @Test
-    public void treeOfKnowledge_is_shared_between_all() {
-        FileContentReplace fcr1 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        RepositoryConsumer otherConsumer = new AbstractRepositoryConsumerTest.MockAbstractRepositoryConsumer();
-        FileContentReplace fcr2 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-
-        fcr1.continueTo(otherConsumer);
-        fcr1.continueTo(fcr2);
-
-        assertTrue(fcr1.getTreeOfKnowledge() == fcr2.getTreeOfKnowledge());
-
-        RepositoryConsumer otherConsumer2 = new AbstractRepositoryConsumerTest.MockAbstractRepositoryConsumer();
-        FileContentReplace fcr3 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-
-        fcr1.continueTo(otherConsumer2);
-        fcr1.continueTo(fcr3);
-
-        assertTrue(fcr1.getTreeOfKnowledge() == fcr2.getTreeOfKnowledge());
-        assertTrue(fcr1.getTreeOfKnowledge() == fcr3.getTreeOfKnowledge());
-    }
-
-    @Test
-    public void treeOfKnowledge_is_not_updated_more_than_once() {
-        Mockery context = new Mockery();
-        TreeOfKnowledge mockToK = context.mock(TreeOfKnowledge.class);
-        Node mockNode = new NodeImpl(new RevisionImpl(1));
-
-        context.checking(new Expectations() {{
-            exactly(1).of(mockToK).consume(mockNode);
-        }});
-
-
-        FileContentReplace fcr1 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        fcr1.setTreeOfKnowledge(mockToK);
-        FileContentReplace fcr2 = new FileContentReplace(MATCH_ANY, EMPTY_CHUNK);
-        fcr1.continueTo(fcr2);
-
-        fcr1.consume(mockNode);
     }
 }


### PR DESCRIPTION
FCR keeps track of its replaced nodes now instead of delegating to TreeOfKnowledge.  Delegating to TreeOfKnowledge currently takes up too much memory.  These changes should fix the memory issues with FCR.