### PR TITLE
FileContentReplace properly handles multiple matches of the same file

### DIFF
--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
@@ -247,4 +247,22 @@ public class FileContentReplaceTest {
                 TestUtil.openResource("dumps/add_and_change_copy_delete.dump"),
                 new ByteArrayInputStream(newDumpStream.toByteArray()));
     }
+
+    @Test
+    public void handle_multiple_matches_across_simple_copies() throws ParseException, IOException {
+        Predicate<Node> nodeMatcher = n -> n.get(NodeHeader.PATH).endsWith("README.txt");
+        FileContentReplace fileContentReplace = new FileContentReplace(nodeMatcher, FileContentReplace.chunkFromString("this text is different\n"));
+
+        ByteArrayOutputStream newDumpStream = new ByteArrayOutputStream();
+        RepositoryWriter svnDumpWriter = new SvnDumpWriter();
+        svnDumpWriter.writeTo(newDumpStream);
+
+        fileContentReplace.continueTo(svnDumpWriter);
+
+        SvnDumpParser.consume(TestUtil.openResource("dumps/simple_copy.dump"), fileContentReplace);
+
+        TestUtil.assertEqualStreams(
+                TestUtil.openResource("dumps/simple_copy2.dump"),
+                new ByteArrayInputStream(newDumpStream.toByteArray()));
+    }
 }

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/replace/FileContentReplaceTest.java
@@ -177,24 +177,6 @@ public class FileContentReplaceTest {
     }
 
     @Test
-    public void tracks_files_across_deletes_with_external_tok() throws ParseException, IOException {
-        Predicate<Node> nodeMatcher = n -> n.getRevision().get().getNumber() == 1 && "README.txt".equals(n.get(NodeHeader.PATH));
-        FileContentReplace fileContentReplace = new FileContentReplace(nodeMatcher, n -> new ContentChunkImpl("i replaced the content\n".getBytes()));
-
-        ByteArrayOutputStream newDumpStream = new ByteArrayOutputStream();
-        RepositoryWriter svnDumpWriter = new SvnDumpWriter();
-        svnDumpWriter.writeTo(newDumpStream);
-
-        fileContentReplace.continueTo(svnDumpWriter);
-
-        SvnDumpParser.consume(TestUtil.openResource("dumps/svn_copy_and_delete.before.dump"), fileContentReplace);
-
-        TestUtil.assertEqualStreams(
-                TestUtil.openResource("dumps/svn_copy_and_delete.after.dump"),
-                new ByteArrayInputStream(newDumpStream.toByteArray()));
-    }
-
-    @Test
     public void tracks_node_in_directory() throws ParseException, IOException {
         Predicate<Node> nodeMatcher = n -> n.getRevision().get().getNumber() == 2 && "dir1/dir2/dir3/README.txt".equals(n.get(NodeHeader.PATH));
         FileContentReplace fileContentReplace = new FileContentReplace(nodeMatcher, n -> new ContentChunkImpl("new content\n".getBytes()));

--- a/src/test/resources/dumps/Makefile
+++ b/src/test/resources/dumps/Makefile
@@ -16,6 +16,11 @@ svn_multi_file_delete:
 simple_branch_and_merge:
 	./scripts/simple_branch_and_merge.sh > simple_branch_and_merge.dump
 
+simple_copy:
+	./scripts/simple_copy.sh > simple_copy.dump
+	./scripts/simple_copy2.sh > simple_copy2.dump
+	echo "Further manual changes are required to update UUID and timestamps in simple_copy2.dump"
+
 utf8_log_message:
 	./scripts/utf8_log_message.sh > utf8_log_message.dump
 

--- a/src/test/resources/dumps/scripts/simple_copy.sh
+++ b/src/test/resources/dumps/scripts/simple_copy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+SVNFLAGS="-q"
+
+CURDIR=$(pwd)
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+cd $SCRIPT_DIR
+
+./setup.sh
+
+
+cd svn-test/checkout/testrepo
+
+mkdir -p trunk/innerdir branches/mybranch/innerdir
+echo "this is a test file" > trunk/innerdir/README.txt
+svn add $SVNFLAGS trunk branches
+svn commit $SVNFLAGS -m "Initial commit."
+svn copy $SVNFLAGS trunk/innerdir/README.txt branches/mybranch/innerdir/README.txt
+svn commit $SVNFLAGS -m "Copying file."
+cd ..
+
+cd $SCRIPT_DIR
+./export.sh
+cd $CURDIR

--- a/src/test/resources/dumps/scripts/simple_copy2.sh
+++ b/src/test/resources/dumps/scripts/simple_copy2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+SVNFLAGS="-q"
+
+CURDIR=$(pwd)
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+cd $SCRIPT_DIR
+
+./setup.sh
+
+
+cd svn-test/checkout/testrepo
+
+mkdir -p trunk/innerdir branches/mybranch/innerdir
+echo "this text is different" > trunk/innerdir/README.txt
+svn add $SVNFLAGS trunk branches
+svn commit $SVNFLAGS -m "Initial commit."
+svn copy $SVNFLAGS trunk/innerdir/README.txt branches/mybranch/innerdir/README.txt
+svn commit $SVNFLAGS -m "Copying file."
+cd ..
+
+cd $SCRIPT_DIR
+./export.sh
+cd $CURDIR

--- a/src/test/resources/dumps/simple_copy.dump
+++ b/src/test/resources/dumps/simple_copy.dump
@@ -1,0 +1,117 @@
+SVN-fs-dump-format-version: 2
+
+UUID: 87ab0b19-995e-437b-bcde-b55f050349cf
+
+Revision-number: 0
+Prop-content-length: 56
+Content-length: 56
+
+K 8
+svn:date
+V 27
+2016-09-12T22:48:22.981522Z
+PROPS-END
+
+Revision-number: 1
+Prop-content-length: 115
+Content-length: 115
+
+K 10
+svn:author
+V 5
+marin
+K 8
+svn:date
+V 27
+2016-09-12T22:48:23.461334Z
+K 7
+svn:log
+V 15
+Initial commit.
+PROPS-END
+
+Node-path: branches
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: branches/mybranch
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: branches/mybranch/innerdir
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk/innerdir
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk/innerdir/README.txt
+Node-kind: file
+Node-action: add
+Prop-content-length: 10
+Text-content-length: 20
+Text-content-md5: 4221d002ceb5d3c9e9137e495ceaa647
+Text-content-sha1: 804d716fc5844f1cc5516c8f0be7a480517fdea2
+Content-length: 30
+
+PROPS-END
+this is a test file
+
+
+Revision-number: 2
+Prop-content-length: 113
+Content-length: 113
+
+K 10
+svn:author
+V 5
+marin
+K 8
+svn:date
+V 27
+2016-09-12T22:48:23.959357Z
+K 7
+svn:log
+V 13
+Copying file.
+PROPS-END
+
+Node-path: branches/mybranch/innerdir/README.txt
+Node-kind: file
+Node-action: add
+Node-copyfrom-rev: 1
+Node-copyfrom-path: trunk/innerdir/README.txt
+Text-copy-source-md5: 4221d002ceb5d3c9e9137e495ceaa647
+Text-copy-source-sha1: 804d716fc5844f1cc5516c8f0be7a480517fdea2
+
+

--- a/src/test/resources/dumps/simple_copy2.dump
+++ b/src/test/resources/dumps/simple_copy2.dump
@@ -1,0 +1,117 @@
+SVN-fs-dump-format-version: 2
+
+UUID: 87ab0b19-995e-437b-bcde-b55f050349cf
+
+Revision-number: 0
+Prop-content-length: 56
+Content-length: 56
+
+K 8
+svn:date
+V 27
+2016-09-12T22:48:22.981522Z
+PROPS-END
+
+Revision-number: 1
+Prop-content-length: 115
+Content-length: 115
+
+K 10
+svn:author
+V 5
+marin
+K 8
+svn:date
+V 27
+2016-09-12T22:48:23.461334Z
+K 7
+svn:log
+V 15
+Initial commit.
+PROPS-END
+
+Node-path: branches
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: branches/mybranch
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: branches/mybranch/innerdir
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk/innerdir
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk/innerdir/README.txt
+Node-kind: file
+Node-action: add
+Prop-content-length: 10
+Text-content-length: 23
+Text-content-md5: 3f379377008845eec385adbc4d89c447
+Text-content-sha1: 26e0638ae4d7e49bd2f39ebc2dd66474303318bb
+Content-length: 33
+
+PROPS-END
+this text is different
+
+
+Revision-number: 2
+Prop-content-length: 113
+Content-length: 113
+
+K 10
+svn:author
+V 5
+marin
+K 8
+svn:date
+V 27
+2016-09-12T22:48:23.959357Z
+K 7
+svn:log
+V 13
+Copying file.
+PROPS-END
+
+Node-path: branches/mybranch/innerdir/README.txt
+Node-kind: file
+Node-action: add
+Node-copyfrom-rev: 1
+Node-copyfrom-path: trunk/innerdir/README.txt
+Text-copy-source-md5: 3f379377008845eec385adbc4d89c447
+Text-copy-source-sha1: 26e0638ae4d7e49bd2f39ebc2dd66474303318bb
+
+


### PR DESCRIPTION
* When a file is copied between revisions without modifying its content, FileContentReplace would incorrectly handle the copy in the later revision.  It now handles the copied files correctly.