### PR TITLE
Clear revision no longer fails if it doesn't actually clear a revision

### DIFF
--- a/src/main/java/com/github/cstroe/svndumpgui/internal/transform/ClearRevision.java
+++ b/src/main/java/com/github/cstroe/svndumpgui/internal/transform/ClearRevision.java
@@ -10,7 +10,6 @@ public class ClearRevision extends AbstractRepositoryMutator {
     private final int fromRevision;
     private final int toRevision;
 
-    private boolean matchedSomething = false;
     private boolean inClearedRevision = false;
 
     public ClearRevision(int revision) {
@@ -41,7 +40,6 @@ public class ClearRevision extends AbstractRepositoryMutator {
     public void consume(Revision revision) {
         if(revisionMatches(revision)) {
             inClearedRevision = true;
-            matchedSomething = true;
         }
         super.consume(revision);
     }
@@ -78,14 +76,6 @@ public class ClearRevision extends AbstractRepositoryMutator {
     public void endRevision(Revision revision) {
         inClearedRevision = false;
         super.endRevision(revision);
-    }
-
-    @Override
-    public void finish() {
-        if(!matchedSomething) {
-            throw new IllegalArgumentException("No revisions matched: " + toString());
-        }
-        super.finish();
     }
 
     @Override

--- a/src/test/java/com/github/cstroe/svndumpgui/internal/transform/ClearRevisionTest.java
+++ b/src/test/java/com/github/cstroe/svndumpgui/internal/transform/ClearRevisionTest.java
@@ -96,12 +96,6 @@ public class ClearRevisionTest {
         new ClearRevision(2,1);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void cant_change_non_existent_revision() throws ParseException {
-        RepositoryConsumer cr = new ClearRevision(3);
-        SvnDumpFileParserTest.consume("dumps/svn_multi_file_delete.dump", cr);
-    }
-
     @Test
     public void consumer_chaining_works() throws ParseException {
         Mockery context = new Mockery();


### PR DESCRIPTION
This allows us to do partial runs of our filter chain.